### PR TITLE
Sapog reference design: Fixed the BOM entry of the power decoupling capacitor; updated README

### DIFF
--- a/sapog_reference_hardware/README.md
+++ b/sapog_reference_hardware/README.md
@@ -5,8 +5,8 @@
 This directory contains the reference hardware design for
 [PX4 Sapog](https://kb.zubax.com/x/cYAh) - an advanced open source ESC firmware.
 
-This specific design is intended as an application note and is not recommended for direct manufacturing.
-The main knowledge to gather from this design is the pinout of the MCU and its immediate connections.
+This specific design is intended as an application note;
+the main knowledge to gather from this design is the pinout of the MCU and its immediate connections.
 The design is implemented in Eagle, version 7 or newer is required.
 
 ## Resources
@@ -14,6 +14,14 @@ The design is implemented in Eagle, version 7 or newer is required.
 * **[HOMEPAGE](https://kb.zubax.com/x/cYAh)**
 * **[SUPPORT & FEEDBACK](https://forum.zubax.com/)**
 * **[FIRMWARE ON GITHUB](https://github.com/PX4/sapog)**
+
+## Design guidelines
+
+1. When choosing the power transistors, keep their dynamic characteristics in mind:
+the switching time must be under 50 nanoseconds.
+Sapog employs somewhat unorthodox methods of state estimation which require a high-speed inverter.
+2. The RC filters in the phase voltage feedback circuits should be designed so that their cutoff frequency
+is around 19 kHz and the output impedance does not exceed 8 kohm.
 
 ## License
 

--- a/sapog_reference_hardware/README.md
+++ b/sapog_reference_hardware/README.md
@@ -22,6 +22,7 @@ the switching time must be under 50 nanoseconds.
 Sapog employs somewhat unorthodox methods of state estimation which require a high-speed inverter.
 2. The RC filters in the phase voltage feedback circuits should be designed so that their cutoff frequency
 is around 19 kHz and the output impedance does not exceed 8 kohm.
+3. Unless your maximum supply voltage exceeds 25 V (6S), do not change the DC link voltage measurement divider.
 
 ## License
 

--- a/sapog_reference_hardware/sapog_reference_hardware.sch
+++ b/sapog_reference_hardware/sapog_reference_hardware.sch
@@ -3393,8 +3393,6 @@ http://www.txccrystal.com/images/pdf/7m-accuracy.pdf</description>
 <part name="D6" library="sapog_reference_hardware" deviceset="1KSMB20A" device=""/>
 <part name="R7" library="R_digikey" deviceset="3K9" device="-0402" technology="-1%" value="3K9"/>
 <part name="C35" library="sapog_reference_hardware" deviceset="C-TANT" device="-3024" value="100µF">
-<attribute name="ALTERNATE#1" value="718-1886-1-ND"/>
-<attribute name="ALTERNATE#2" value="399-5221-1-ND"/>
 </part>
 <part name="GND44" library="sapog_reference_hardware" deviceset="GND" device=""/>
 <part name="GND45" library="sapog_reference_hardware" deviceset="GND" device=""/>


### PR DESCRIPTION
25 V tantalum capacitors degrade quickly, the new recommendation is to use 35 V rated capacitors. For more info, see <https://forum.zubax.com/t/configuring-orel-for-particular-motor/80/23?u=pavel-kirienko>