### PR TITLE
Fix badge rendering and update Pixhawk Series link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Join the chat at Gitter](https://img.shields.io/badge/Chat-Gitter-blue?style=flat&logo=gitter)](https://gitter.im/PX4/Hardware?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![FMUv1](https://img.shields.io/badge/FMUv1-Discontinued-pink?style=flat)](FMUv1/README.md) [![FMUv2](https://img.shields.io/badge/FMUv2-Pixhawk%201-skyblue?style=flat)](FMUv2/README.md) [![FMUv3](https://img.shields.io/badge/FMUv3-Pixhawk%202-brown?style=flat)](FMUv3_REV_D/README.md) [![FMUv4](https://img.shields.io/badge/FMUv4-Pixracer-gold?style=flat)](FMUv4/README.md) [![FMUv4X](https://img.shields.io/badge/FMUv4X-Pixhawk%203%20Pro-orange?style=flat)](#fmu_versions) [![FMUv5](https://img.shields.io/badge/FMUv5-Pixhawk%204-green?style=flat)](FMUv5/README.md) [![FMUv5X](https://img.shields.io/badge/FMUv5X-Pixhawk%205X-teal?style=flat)](#fmu_versions)
+[![FMUv1](https://img.shields.io/badge/FMUv1-Discontinued-pink?style=flat)](FMUv1/README.md) [![FMUv2](https://img.shields.io/badge/FMUv2-Pixhawk%201-skyblue?style=flat)](FMUv2/README.md) [![FMUv3](https://img.shields.io/badge/FMUv3-Pixhawk%202-brown?style=flat)](FMUv3_REV_D/README.md) [![FMUv4](https://img.shields.io/badge/FMUv4-Pixracer-gold?style=flat)](FMUv4/README.md) [![FMUv4X](https://img.shields.io/badge/FMUv4X-Pixhawk%203%20Pro-orange?style=flat)](#fmu_versions) [![FMUv5](https://img.shields.io/badge/FMUv5-Pixhawk%204-green?style=flat)](FMUv5/README.md) [![FMUv5X](https://img.shields.io/badge/FMUv5X-Pixhawk%205X-teal?style=flat)](#fmu-versions)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Pixhawk Hardware Designs
 
-[![Join the chat at https://gitter.im/PX4/Hardware](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PX4/Hardware?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
+<div align="center">
+
+[![Join the chat at Gitter](https://img.shields.io/badge/Chat-Gitter-blue?style=flat&logo=gitter)](https://gitter.im/PX4/Hardware?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+[![FMUv1](https://img.shields.io/badge/FMUv1-Discontinued-pink?style=flat)](FMUv1/README.md) [![FMUv2](https://img.shields.io/badge/FMUv2-Pixhawk%201-skyblue?style=flat)](FMUv2/README.md) [![FMUv3](https://img.shields.io/badge/FMUv3-Pixhawk%202-brown?style=flat)](FMUv3_REV_D/README.md) [![FMUv4](https://img.shields.io/badge/FMUv4-Pixracer-gold?style=flat)](FMUv4/README.md) [![FMUv4X](https://img.shields.io/badge/FMUv4X-Pixhawk%203%20Pro-orange?style=flat)](#fmu_versions) [![FMUv5](https://img.shields.io/badge/FMUv5-Pixhawk%204-green?style=flat)](FMUv5/README.md) [![FMUv5X](https://img.shields.io/badge/FMUv5X-Pixhawk%205X-teal?style=flat)](#fmu_versions)
+
+</div>
 
 [Pixhawk](http://pixhawk.org) is an independent open-hardware project that aims to provide "the gold standard" for readily-available, hiqh-quality and low-cost autopilot hardware designs for the academic, hobby and developer communities.
 Pixhawk supports multiple flight stacks: PX4 ® and ArduPilot ®.
@@ -18,6 +24,7 @@ In essence, this definition allows anyone to freely study, modify, distribute, m
 Hardware designs delivered by the project are listed below.
 
 <span id="fmu_designs"></span>
+
 ### FMU (Autopilot) Designs
 
 Pixhawk FMU open designs include all information required to create an autopilot hardware product that is *firmware compatible* with other hardware created from the same design.
@@ -41,6 +48,8 @@ These are provided in the form of PCB layout files.
 
 The reference hardware files are shared under the same [license](#licenses) as the associated open design, and hence may be used in the same way(s).
 
+<span id="fmu_versions"></span>
+
 #### FMU Versions
 
 The Pixhawk project has evolved the FMU design through a number of verisons.
@@ -61,7 +70,7 @@ FMUv4X | 2017 | Pixhawk 3 Pro | 168 MHz M4 | Slightly increased RAM. More serial
 FMUv5X | 2019 | Pixhawk 5X | 200 MHz M7 | Temp-calibrated, redundant sensors.
 
 
-> **Note** Products based on Pixhawk designs are listed here: [PX4 User Guide > Pixhawk Series]( https://docs.px4.io/master/en/flight_controller/pixhawk_series.html#pixhawk-series).
+> **Note** Products based on Pixhawk designs are listed here: [PX4 User Guide > Pixhawk Series]( https://docs.px4.io/main/en/flight_controller/pixhawk_series.html#pixhawk-series).
 
 
 #### Derived FMU Products

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 [Pixhawk](http://pixhawk.org) is an independent open-hardware project that aims to provide "the gold standard" for readily-available, hiqh-quality and low-cost autopilot hardware designs for the academic, hobby and developer communities.
 Pixhawk supports multiple flight stacks: PX4 ® and ArduPilot ®.
 
-> **Note** Designs are provided for a number of components used in unmanned vehicles, including: Autopilots (Flight Management Units - FMUs), ESCs (electronic speed controllers), optical flow sensors, etc.
+> [!NOTE]
+> Designs are provided for a number of components used in unmanned vehicles, including: Autopilots (Flight Management Units - FMUs), ESCs (electronic speed controllers), optical flow sensors, etc.
 
 ## What are Open Hardware Designs?
 
@@ -30,16 +31,17 @@ Hardware designs delivered by the project are listed below.
 Pixhawk FMU open designs include all information required to create an autopilot hardware product that is *firmware compatible* with other hardware created from the same design.
 Manufacturers are encouraged to take the designs and create products that are best suited to a particular market or use case (e.g. for very small vehicles, or those that operate at environmental extremes).
 
-> **Note** While a physical connector standard is not mandated, newer products generally follow the [Pixhawk Connector Standard](https://pixhawk.org/pixhawk-connector-standard/).
-
+> [!NOTE]
+> While a physical connector standard is not mandated, newer products generally follow the [Pixhawk Connector Standard](https://pixhawk.org/pixhawk-connector-standard/).
 
 #### Design Specifications
 
 Designs are *usually* specified in the form of *schematics* that show all included components (CPU, sensors, etc.), how they are connected, and their pin mappings.
 They may also include a BOM (bill of materials).
 
-> **Note** Not all designs deliver schematics.
-  A minimal design needs to contain enough information for manufacturers to create a compatible products; this can also be achieved using a precise pinout definition and information about connections of internal/external busses, etc.
+> [!NOTE]
+> Not all designs deliver schematics.
+> A minimal design needs to contain enough information for manufacturers to create a compatible products; this can also be achieved using a precise pinout definition and information about connections of internal/external busses, etc.
 
 #### Open Reference Hardware
 
@@ -47,8 +49,6 @@ The project provides *open reference hardware/layouts* for **some** open designs
 These are provided in the form of PCB layout files.
 
 The reference hardware files are shared under the same [license](#licenses) as the associated open design, and hence may be used in the same way(s).
-
-<span id="fmu_versions"></span>
 
 #### FMU Versions
 
@@ -69,10 +69,8 @@ FMUv4X | 2017 | Pixhawk 3 Pro | 168 MHz M4 | Slightly increased RAM. More serial
 [FMUv5](FMUv5/README.md) | 2018 | Pixhawk 4 | 200 MHz M7 | New processor (F7). Much faster. More RAM. More CAN busses. Much more configurable.<br>> **Note** Minimum specification provided (pinout info, but no schematics).
 FMUv5X | 2019 | Pixhawk 5X | 200 MHz M7 | Temp-calibrated, redundant sensors.
 
-
 > [!NOTE]
 > Products based on Pixhawk designs are listed here: [PX4 User Guide > Pixhawk Series](https://docs.px4.io/main/en/flight_controller/pixhawk_series.html#pixhawk-series).
-
 
 #### Derived FMU Products
 
@@ -94,7 +92,6 @@ Relevant products are listed below:
 - [IMUv3_REV_C](IMUv3_REV_C)
 - [PSMv3_REV_C](PSMv3_REV_C)
 
-<span id="dev_call"></span>
 ## Dev Call
 
 Pixhawk standards are developed in a weekly public developer call.
@@ -109,19 +106,19 @@ Pixhawk project schematics and reference designs are licensed under [CC BY-SA 3]
 
 The license allows you to use, sell, share, modify and build on the files in almost any way you like - provided that you give credit/attribution, and that you share any changes that you make under the same open source license (see the [human readable version of the license](https://creativecommons.org/licenses/by-sa/3.0/) for a concise summary of the rights and obligations).
 
-> **Note** Boards that are *derived directly* from Pixhawk schematic files (or reference boards) must be open sourced.
-  They can't be commercially licensed as proprietary products.
+> [!NOTE]
+> Boards that are *derived directly* from Pixhawk schematic files (or reference boards) must be open sourced.
+> They can't be commercially licensed as proprietary products.
 
 Manufacturers can create (compatible) *fully independent products* by first generating fresh schematic files that have the same pin mapping/components as the FMU designs.
 Products that are based on independently created schematics are considered original works, and can be licensed as required.
 
-<span id="trademarks"></span>
 ## Trademarks
 
 The term *Pixhawk* is a trademark, and may not be used in product names without explicit permission from the trademark owner.
 
 Typically this trademark is granted to the first board based on a particular FMU design and/or boards that use Pixhawk open reference hardware layouts.
 
-> **Note** A "Pixhawk" is an autopilot that has been been given permission to use the Pixhawk trademark in its name.
-  While other boards are based on the "Pixhawk FMU Standard", the are not *strictly speaking* "Pixhawks".
-
+> [!NOTE]
+> A "Pixhawk" is an autopilot that has been been given permission to use the Pixhawk trademark in its name.
+> While other boards are based on the "Pixhawk FMU Standard", the are not *strictly speaking* "Pixhawks".

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ FMUv4X | 2017 | Pixhawk 3 Pro | 168 MHz M4 | Slightly increased RAM. More serial
 FMUv5X | 2019 | Pixhawk 5X | 200 MHz M7 | Temp-calibrated, redundant sensors.
 
 
-> **Note** Products based on Pixhawk designs are listed here: [PX4 User Guide > Pixhawk Series]( https://docs.px4.io/main/en/flight_controller/pixhawk_series.html#pixhawk-series).
+> [!NOTE]
+> Products based on Pixhawk designs are listed here: [PX4 User Guide > Pixhawk Series](https://docs.px4.io/main/en/flight_controller/pixhawk_series.html#pixhawk-series).
 
 
 #### Derived FMU Products


### PR DESCRIPTION
This PR addresses issue [#122](https://github.com/PX4/Hardware/issues/122) with the following improvements:

1. **Fix Gitter Badge Rendering:**
   - Adjusted the Gitter badge styling to ensure consistent rendering across platforms.

2. **Updated Pixhawk Series Link:**
   - Replaced the outdated link to the Pixhawk Series documentation with the correct and up-to-date URL.

3. **Added FMU Version Badges:**
   - Introduced badges for FMU versions, providing an at-a-glance view of the different FMU designs.
   